### PR TITLE
[STUDIO-3193] Support mapping multiple TestRail ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.katalon</groupId>
     <artifactId>katalon-studio-testrail-plugin</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
 
     <packaging>bundle</packaging>
 

--- a/src/main/java/com/katalon/plugin/testrail/TestRailTestCaseIntegration.java
+++ b/src/main/java/com/katalon/plugin/testrail/TestRailTestCaseIntegration.java
@@ -2,12 +2,15 @@ package com.katalon.plugin.testrail;
 
 import com.katalon.platform.api.model.Integration;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
 public class TestRailTestCaseIntegration implements Integration {
+    private static final String TESTRAIL_TESTCASE_DELIMITER = ",";
     private String testCaseId;
 
     public void setTestCaseId(String testCaseId) {
@@ -15,7 +18,21 @@ public class TestRailTestCaseIntegration implements Integration {
     }
 
     public String getTestCaseId() {
-        return testCaseId != null ? testCaseId.replaceAll("\\D", "") : null;
+        if (StringUtils.isBlank(testCaseId)) {
+            return StringUtils.EMPTY;
+        }
+
+        ArrayList<Long> results = new ArrayList<>();
+        String[] testRailTestCaseIds = testCaseId.split(TESTRAIL_TESTCASE_DELIMITER);
+        
+        for (String id : testRailTestCaseIds) {
+            String filtered = id.trim().replaceAll("\\D", "");
+            if (!filtered.isEmpty()) {
+                results.add(Long.parseLong(filtered));
+            }
+        }
+
+        return results.stream().map(String::valueOf).collect(Collectors.joining(TESTRAIL_TESTCASE_DELIMITER));
     }
 
     @Override


### PR DESCRIPTION
**Description**
Changes:
- Support adding multiple TestRail IDs in a Studio test case, separated by a comma 
- Test cases with multiple TestRail IDs can still be queried in a dynamic test suite
- Ensure that we can upload KS test execution results to multiple linked TestRail IDs.

**References**
[STUDIO-3193](https://katalon.atlassian.net/browse/STUDIO-3193)

[STUDIO-3193]: https://katalon.atlassian.net/browse/STUDIO-3193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ